### PR TITLE
Fix removing pads from compositor bin

### DIFF
--- a/lib/membrane/video_compositor/video_compositor.ex
+++ b/lib/membrane/video_compositor/video_compositor.ex
@@ -75,6 +75,10 @@ defmodule Membrane.VideoCompositor do
   end
 
   @impl true
+  def handle_pad_removed(Pad.ref(:input, pad_id), _context, state),
+    do: {[remove_child: {:framerate_converter, pad_id}], state}
+
+  @impl true
   def handle_pad_added(Pad.ref(:input, pad_id), context, state) do
     spec =
       bin_input(Pad.ref(:input, pad_id))


### PR DESCRIPTION
After this fix you'll be able to unlink pads from bin. Right now it's not possible because `framerate converter` is never removed. 
Also I recommend to include pad removing and caps that change over time in tests.