### PR TITLE
Fixed removing framerate converter.

### DIFF
--- a/lib/membrane/video_compositor/video_compositor.ex
+++ b/lib/membrane/video_compositor/video_compositor.ex
@@ -75,7 +75,7 @@ defmodule Membrane.VideoCompositor do
   def handle_pad_added(Pad.ref(:input, pad_id), context, state) do
     spec =
       bin_input(Pad.ref(:input, pad_id))
-      |> child({:framerate_converter, make_ref()}, %FramerateConverter{
+      |> child({:framerate_converter, pad_id}, %FramerateConverter{
         framerate: state.output_stream_format.framerate
       })
       |> via_in(Pad.ref(:input, pad_id),


### PR DESCRIPTION
The `FramerateConverter` had been identified by `make_ref()`, which hadn't been saved anywhere, so we had no way of identifying the converter when the pad was being removed.

It migth be worthwhile to add a test, which checks if children are correctly removed when pad has been removed, but this is just a quick fix for now.