### PR TITLE
Simplified scene API design

### DIFF
--- a/lib/membrane/video_compositor/examples/easy.ex
+++ b/lib/membrane/video_compositor/examples/easy.ex
@@ -1,4 +1,4 @@
-defmodule Membrane.VideoCompositor.Examples.Simple do
+defmodule Membrane.VideoCompositor.Examples.Easy do
   @moduledoc """
   An easy example simulates the layout of a video conferencing app.
   There are 4 video inputs. All of them get their corners rounded. Then,
@@ -16,6 +16,7 @@ defmodule Membrane.VideoCompositor.Examples.Simple do
 
   @one_third 1.0 / 3.0
   @sixteen_tenths 16.0 / 9.0
+  @corners_rounding %CornersRounding{border_radius: 100}
 
   @strip_overlay %Overlay{
     input_map: %{
@@ -47,28 +48,22 @@ defmodule Membrane.VideoCompositor.Examples.Simple do
   }
 
   %Scene{
-    transformations: %{
-      corners_rounding: %CornersRounding{border_radius: 100}
-    },
-    layouts: %{
-      overlay: @strip_overlay
-    },
     objects: [
       rounded_1: %Texture{
         input: :video_1,
-        transformations: [:corners_rounding]
+        transformations: [@corners_rounding]
       },
       rounded_2: %Texture{
         input: :video_2,
-        transformations: [:corners_rounding]
+        transformations: [@corners_rounding]
       },
       rounded_3: %Texture{
         input: :video_3,
-        transformations: [:corners_rounding]
+        transformations: [@corners_rounding]
       },
       rounded_4: %Texture{
         input: :video_4,
-        transformations: [:corners_rounding]
+        transformations: [@corners_rounding]
       },
       final_object: %Layout{
         inputs_map: %{
@@ -77,7 +72,7 @@ defmodule Membrane.VideoCompositor.Examples.Simple do
           rounded_3: :bottom_left,
           rounded_4: :background
         },
-        layout: :overlay,
+        layout: @strip_overlay,
         resolution: %Resolution{width: 1920, height: 1080}
       }
     ],

--- a/lib/membrane/video_compositor/examples/hard.ex
+++ b/lib/membrane/video_compositor/examples/hard.ex
@@ -36,7 +36,7 @@ defmodule Membrane.VideoCompositor.Examples.Hard do
         resolution: :video_1
       },
       rounded: %Texture{input: :merged, transformations: [@corners_rounding]},
-      ball: %Texture{input: :video_2, transformations: [@ball]},
+      ball: %Texture{input: :video_3, transformations: [@ball]},
       final_object: %Layout{
         inputs_map: %{
           rotated: :top_left,
@@ -49,4 +49,25 @@ defmodule Membrane.VideoCompositor.Examples.Hard do
     ],
     output: :final_objects
   }
+
+  # Here's how I would like for in to look in the final version, with macros etc.
+  # I think that design would be more coherent with membrane.
+
+  # scene = %Scene{
+  #   elements: %{
+  #     rotate: %Rotate{degrees: 90},
+  #     ball: ToBall,
+  #     corners_rounding: %CornersRounding{border_radius: 5},
+  #     three_vids_grid: %Grid{videos_count: 3},
+  #     merging: Merging
+  #   },
+  #   rendering: [
+  #     link(:video_1) |> with_transforms([:rotate]) |> via_in(:top_left) |> to(:three_vids_grid),
+  #     link(:video_1) |> via_in(0) |> to(:merging),
+  #     link(:video_2) |> via_in(1) |> to(:merging),
+  #     link(:merging) |> via_in(:top_left) |> to(:three_vids_grid)
+  #     link(:video_3) |> with_transforms([:ball]) |> via_in(:bottom) |> to(:three_vids_grid)
+  #     link(:three_vids_grid) |> to(:output)
+  #   ]
+  # }
 end

--- a/lib/membrane/video_compositor/examples/hard.ex
+++ b/lib/membrane/video_compositor/examples/hard.ex
@@ -1,0 +1,52 @@
+defmodule Membrane.VideoCompositor.Examples.Hard do
+  @moduledoc """
+  A hard example takes three videos, applies varied transformations to them, and puts
+  them together on the final canvas
+  - The first video is simply rotated and then put in the top left corner
+  - The second video is merged with the first video. The result gets
+  corner rounding and is put in the top right corner
+  - The third video is turned into a ball and put in the middle bottom of the screen
+  """
+
+  alias Membrane.VideoCompositor.VideoTransformations.TextureTransformations.CornersRounding
+
+  alias Membrane.VideoCompositor.Examples.Mock.Layouts.{Grid, Merging}
+  alias Membrane.VideoCompositor.Examples.Mock.Transformations.{Rotate, ToBall}
+  alias Membrane.VideoCompositor.Scene
+  alias Membrane.VideoCompositor.Scene.{Layout, Resolution, Texture}
+
+  @rotate %Rotate{degrees: 90}
+  @ball ToBall
+  @corners_rounding %CornersRounding{border_radius: 5}
+  @three_vids_grid %Grid{videos_count: 3}
+  @merging Merging
+
+  %Scene{
+    objects: [
+      rotated: %Texture{
+        input: :video_1,
+        transformations: [@rotate]
+      },
+      merged: %Layout{
+        inputs_map: %{
+          video_1: 0,
+          video_2: 1
+        },
+        layout: @merging,
+        resolution: :video_1
+      },
+      rounded: %Texture{input: :merged, transformations: [@corners_rounding]},
+      ball: %Texture{input: :video_2, transformations: [@ball]},
+      final_object: %Layout{
+        inputs_map: %{
+          rotated: :top_left,
+          rounded: :top_right,
+          ball: :bottom
+        },
+        layout: @three_vids_grid,
+        resolution: %Resolution{width: 1920, height: 1080}
+      }
+    ],
+    output: :final_objects
+  }
+end

--- a/lib/membrane/video_compositor/examples/mock/layouts/grid.ex
+++ b/lib/membrane/video_compositor/examples/mock/layouts/grid.ex
@@ -3,4 +3,8 @@ defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Grid do
 
   @enforce_keys [:videos_count]
   defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          videos_count: non_neg_integer()
+        }
 end

--- a/lib/membrane/video_compositor/examples/mock/layouts/grid.ex
+++ b/lib/membrane/video_compositor/examples/mock/layouts/grid.ex
@@ -1,0 +1,6 @@
+defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Grid do
+  @moduledoc false
+
+  @enforce_keys [:videos_count]
+  defstruct @enforce_keys
+end

--- a/lib/membrane/video_compositor/examples/mock/layouts/merging.ex
+++ b/lib/membrane/video_compositor/examples/mock/layouts/merging.ex
@@ -1,0 +1,3 @@
+defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Merging do
+  @moduledoc false
+end

--- a/lib/membrane/video_compositor/examples/mock/layouts/overlay.ex
+++ b/lib/membrane/video_compositor/examples/mock/layouts/overlay.ex
@@ -2,6 +2,7 @@ defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Overlay do
   @moduledoc false
 
   alias Membrane.VideoCompositor.Examples.Mock.Layouts.Position
+  alias Membrane.VideoCompositor.Scene.Object
 
   @enforce_keys [:input_map]
   defstruct @enforce_keys
@@ -11,6 +12,6 @@ defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Overlay do
   transformation / layouts
   """
   @type t :: %__MODULE__{
-          input_map: %{atom() => Position.t()}
+          input_map: %{Object.name_t() => Position.t()}
         }
 end

--- a/lib/membrane/video_compositor/examples/mock/layouts/overlay.ex
+++ b/lib/membrane/video_compositor/examples/mock/layouts/overlay.ex
@@ -1,0 +1,16 @@
+defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Overlay do
+  @moduledoc false
+
+  alias Membrane.VideoCompositor.Examples.Mock.Layouts.Position
+
+  @enforce_keys [:input_map]
+  defstruct @enforce_keys
+
+  @typedoc """
+  Overlays textures received received from input pad or rendered from previous
+  transformation / layouts
+  """
+  @type t :: %__MODULE__{
+          input_map: %{atom() => Position.t()}
+        }
+end

--- a/lib/membrane/video_compositor/examples/mock/layouts/position.ex
+++ b/lib/membrane/video_compositor/examples/mock/layouts/position.ex
@@ -1,8 +1,8 @@
 defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Position do
   @moduledoc false
 
-  @enforce_keys [:top_left_corner, :width, :height, :z_value]
-  defstruct @enforce_keys
+  @enforce_keys [:top_left_corner, :width, :height]
+  defstruct @enforce_keys ++ [z_value: 0.0]
 
   @typedoc """
   Float in [0, 1] range. Widely used in graphic rendering, to determine distance, color etc.

--- a/lib/membrane/video_compositor/examples/mock/layouts/position.ex
+++ b/lib/membrane/video_compositor/examples/mock/layouts/position.ex
@@ -1,0 +1,18 @@
+defmodule Membrane.VideoCompositor.Examples.Mock.Layouts.Position do
+  @moduledoc false
+
+  @enforce_keys [:top_left_corner, :width, :height, :z_value]
+  defstruct @enforce_keys
+
+  @typedoc """
+  Float in [0, 1] range. Widely used in graphic rendering, to determine distance, color etc.
+  """
+  @type unit_range_t :: float()
+
+  @type t :: %__MODULE__{
+          top_left_corner: {unit_range_t(), unit_range_t()},
+          width: unit_range_t() | :auto,
+          height: unit_range_t() | :auto,
+          z_value: unit_range_t()
+        }
+end

--- a/lib/membrane/video_compositor/examples/mock/transformations/corners_rounding.ex
+++ b/lib/membrane/video_compositor/examples/mock/transformations/corners_rounding.ex
@@ -1,0 +1,19 @@
+defmodule Membrane.VideoCompositor.Examples.Mock.Transformations.CornersRounding do
+  @moduledoc false
+
+  @enforce_keys [:border_radius]
+  defstruct @enforce_keys
+
+  @typedoc """
+  Describe corners rounding texture transformation parameter.
+  Corner rounding transformation can be imagined as placing four circles with specified radius
+  adjoining to frame borders, placed inside frame and making space between circle edge and
+  nearest frame corner transparent.
+  ## Values
+  - border_radius: non negative integer representing radius of circle "cutting"
+  frame corner part.
+  """
+  @type t :: %__MODULE__{
+          border_radius: non_neg_integer()
+        }
+end

--- a/lib/membrane/video_compositor/examples/mock/transformations/rotate.ex
+++ b/lib/membrane/video_compositor/examples/mock/transformations/rotate.ex
@@ -1,0 +1,10 @@
+defmodule Membrane.VideoCompositor.Examples.Mock.Transformations.Rotate do
+  @moduledoc false
+
+  @enforce_keys [:degrees]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          degrees: non_neg_integer()
+        }
+end

--- a/lib/membrane/video_compositor/examples/mock/transformations/to_ball.ex
+++ b/lib/membrane/video_compositor/examples/mock/transformations/to_ball.ex
@@ -1,0 +1,3 @@
+defmodule Membrane.VideoCompositor.Examples.Mock.Transformations.ToBall do
+  @moduledoc false
+end

--- a/lib/membrane/video_compositor/examples/simple.ex
+++ b/lib/membrane/video_compositor/examples/simple.ex
@@ -1,0 +1,103 @@
+defmodule Membrane.VideoCompositor.Examples.Simple do
+  @moduledoc """
+  An easy example simulates the layout of a video conferencing app.
+  There are 4 video inputs. All of them get their corners rounded. Then,
+  one of them is chosen as a main video (which takes most of the screen),
+  while the rest are scaled-down and put in a side strip on top of the main video.
+  """
+
+  alias Membrane.VideoCompositor.Examples.Mock.Layouts.Overlay
+  alias Membrane.VideoCompositor.Examples.Mock.Layouts.Position
+  alias Membrane.VideoCompositor.Examples.Mock.Transformations.CornersRounding
+  alias Membrane.VideoCompositor.Scene
+  alias Membrane.VideoCompositor.Scene.Layout
+  alias Membrane.VideoCompositor.Scene.Resolution
+  alias Membrane.VideoCompositor.Scene.Texture
+
+  @one_third 1.0 / 3.0
+  @sixteen_tenths 16.0 / 9.0
+
+  @strip_overlay %Overlay{
+    input_map: %{
+      background: %Position{
+        top_left_corner: {0.0, 0.0},
+        width: 1.0,
+        height: 1.0,
+        z_value: 0.0
+      },
+      top_left: %Position{
+        top_left_corner: {0.0, 0.0},
+        width: @sixteen_tenths * @one_third,
+        height: @one_third,
+        z_value: 1.0
+      },
+      center_left: %Position{
+        top_left_corner: {0.0, @one_third},
+        width: @sixteen_tenths * @one_third,
+        height: @one_third,
+        z_value: 1.0
+      },
+      bottom_left: %Position{
+        top_left_corner: {0.0, 2 * @one_third},
+        width: @sixteen_tenths * @one_third,
+        height: @one_third,
+        z_value: 1.0
+      }
+    }
+  }
+
+  %Scene{
+    transformations: %{
+      corners_rounding: %CornersRounding{border_radius: 100}
+    },
+    layouts: %{
+      overlay: @strip_overlay
+    },
+    objects: [
+      rounded_1: %Texture{
+        input: :video_1,
+        transformations: [:corners_rounding]
+      },
+      rounded_2: %Texture{
+        input: :video_2,
+        transformations: [:corners_rounding]
+      },
+      rounded_3: %Texture{
+        input: :video_3,
+        transformations: [:corners_rounding]
+      },
+      rounded_4: %Texture{
+        input: :video_4,
+        transformations: [:corners_rounding]
+      },
+      final_object: %Layout{
+        inputs_map: %{
+          rounded_1: :top_left,
+          rounded_2: :center_left,
+          rounded_3: :bottom_left,
+          rounded_4: :background
+        },
+        layout: :overlay,
+        resolution: %Resolution{width: 1920, height: 1080}
+      }
+    ],
+    output: :final_object
+  }
+
+  # Here's how I would like for in to look in the final version, with macros etc.
+  # I think that design would be more coherent with membrane.
+
+  # scene = %Scene{
+  #   elements: %{
+  #     corners_rounding: %CornersRounding{border_radius: 100},
+  #     overlay: @strip_overlay
+  #   },
+  #   rendering: [
+  #     link(:video_1) |> with_transforms([:corners_rounding]) |> via_in(:top_left) |> to(:overlay),
+  #     link(:video_2) |> with_transforms([:corners_rounding]) |> via_in(:center_left) |> to(:overlay),
+  #     link(:video_3) |> with_transforms([:corners_rounding]) |> via_in(:bottom_left) |> to(:overlay),
+  #     link(:video_4) |> with_transforms([:corners_rounding]) |> via_in(:background) |> to(:overlay)
+  #     link(:overlay) |> to(:output)
+  #   ]
+  # }
+end

--- a/lib/membrane/video_compositor/scene.ex
+++ b/lib/membrane/video_compositor/scene.ex
@@ -1,10 +1,18 @@
 defmodule Membrane.VideoCompositor.Scene do
-  @moduledoc false
+  @moduledoc """
+  Structure representing a top level specification of what Video Compositor is
+  supposed to render.
+  """
 
   alias Membrane.VideoCompositor.Scene.Object
 
-  defstruct [:objects, :output, layouts: [], transformations: []]
+  @enforce_keys [:objects, :output]
+  defstruct @enforce_keys
 
+  @typedoc """
+  Defines all modifications applied to frames incoming to Video Compositor
+  via input pads and specify how output frame should look like.
+  """
   @type t :: %__MODULE__{
           objects: [{Object.name_t(), Object.t()}],
           output: Object.name_t()

--- a/lib/membrane/video_compositor/scene.ex
+++ b/lib/membrane/video_compositor/scene.ex
@@ -1,0 +1,16 @@
+defmodule Membrane.VideoCompositor.Scene do
+  @moduledoc false
+
+  alias Membrane.VideoCompositor.Scene.LayoutSpec
+  alias Membrane.VideoCompositor.Scene.Object
+  alias Membrane.VideoCompositor.Scene.TransformationSpec
+
+  defstruct [:objects, :output, layouts: [], transformations: []]
+
+  @type t :: %__MODULE__{
+          transformations: [{Object.name_t(), TransformationSpec.definition_t()}],
+          layouts: %{Object.name_t() => LayoutSpec.definition_t()},
+          objects: [{Object.name_t(), Object.t()}],
+          output: Object.name_t()
+        }
+end

--- a/lib/membrane/video_compositor/scene.ex
+++ b/lib/membrane/video_compositor/scene.ex
@@ -1,15 +1,11 @@
 defmodule Membrane.VideoCompositor.Scene do
   @moduledoc false
 
-  alias Membrane.VideoCompositor.Scene.LayoutSpec
   alias Membrane.VideoCompositor.Scene.Object
-  alias Membrane.VideoCompositor.Scene.TransformationSpec
 
   defstruct [:objects, :output, layouts: [], transformations: []]
 
   @type t :: %__MODULE__{
-          transformations: [{Object.name_t(), TransformationSpec.definition_t()}],
-          layouts: %{Object.name_t() => LayoutSpec.definition_t()},
           objects: [{Object.name_t(), Object.t()}],
           output: Object.name_t()
         }

--- a/lib/membrane/video_compositor/scene/layout.ex
+++ b/lib/membrane/video_compositor/scene/layout.ex
@@ -1,0 +1,22 @@
+defmodule Membrane.VideoCompositor.Scene.Layout do
+  @moduledoc false
+
+  alias Membrane.Pad
+  alias Membrane.VideoCompositor.Scene.LayoutSpec
+  alias Membrane.VideoCompositor.Scene.Object
+  alias Membrane.VideoCompositor.Scene.Resolution
+  alias Membrane.VideoCompositor.Scene.TransformationSpec
+
+  @type input_t :: Pad.name_t() | TransformationSpec.definition_t() | LayoutSpec.definition_t()
+  @type resolution_t ::
+          Pad.name_t() | TransformationSpec.definition_t() | LayoutSpec.definition_t()
+
+  @enforce_keys [:inputs_map, :layout, :resolution]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          inputs_map: %{Object.name_t() => any()},
+          layout: LayoutSpec.definition_t(),
+          resolution: Resolution.t()
+        }
+end

--- a/lib/membrane/video_compositor/scene/layout.ex
+++ b/lib/membrane/video_compositor/scene/layout.ex
@@ -1,22 +1,23 @@
 defmodule Membrane.VideoCompositor.Scene.Layout do
-  @moduledoc false
+        @moduledoc """
+        Wraps specified implemented layout with input sources and output frame resolution.
+        """
 
-  alias Membrane.Pad
-  alias Membrane.VideoCompositor.Scene.LayoutSpec
-  alias Membrane.VideoCompositor.Scene.Object
-  alias Membrane.VideoCompositor.Scene.Resolution
-  alias Membrane.VideoCompositor.Scene.TransformationSpec
+        alias Membrane.Pad
+        alias Membrane.VideoCompositor.Scene.{Object, Resolution}
 
-  @type input_t :: Pad.name_t() | TransformationSpec.definition_t() | LayoutSpec.definition_t()
-  @type resolution_t ::
-          Pad.name_t() | TransformationSpec.definition_t() | LayoutSpec.definition_t()
+        @enforce_keys [:inputs_map, :layout, :resolution]
+        defstruct @enforce_keys
 
-  @enforce_keys [:inputs_map, :layout, :resolution]
-  defstruct @enforce_keys
-
-  @type t :: %__MODULE__{
-          inputs_map: %{Object.name_t() => any()},
-          layout: LayoutSpec.definition_t(),
-          resolution: Resolution.t()
-        }
-end
+        @typedoc """
+        Wraps layout (like Grid, Overlay etc.) with mapping of input objects
+        (which rendered output frames will be passed as inputs into layout).
+        Specifies resolution of layout output frame - if object name is passed
+        as resolution, it'll use resolution of object's output frame.
+        """
+        @type t :: %__MODULE__{
+                inputs_map: %{Object.name_t() => any()},
+                layout: LayoutSpec.definition_t(),
+                resolution: Resolution.t() | Object.name_t()
+              }
+      end

--- a/lib/membrane/video_compositor/scene/layout.ex
+++ b/lib/membrane/video_compositor/scene/layout.ex
@@ -1,23 +1,22 @@
 defmodule Membrane.VideoCompositor.Scene.Layout do
-        @moduledoc """
-        Wraps specified implemented layout with input sources and output frame resolution.
-        """
+  @moduledoc """
+  Wraps specified implemented layout with input sources and output frame resolution.
+  """
 
-        alias Membrane.Pad
-        alias Membrane.VideoCompositor.Scene.{Object, Resolution}
+  alias Membrane.VideoCompositor.Scene.{LayoutSpec, Object, Resolution}
 
-        @enforce_keys [:inputs_map, :layout, :resolution]
-        defstruct @enforce_keys
+  @enforce_keys [:inputs_map, :layout, :resolution]
+  defstruct @enforce_keys
 
-        @typedoc """
-        Wraps layout (like Grid, Overlay etc.) with mapping of input objects
-        (which rendered output frames will be passed as inputs into layout).
-        Specifies resolution of layout output frame - if object name is passed
-        as resolution, it'll use resolution of object's output frame.
-        """
-        @type t :: %__MODULE__{
-                inputs_map: %{Object.name_t() => any()},
-                layout: LayoutSpec.definition_t(),
-                resolution: Resolution.t() | Object.name_t()
-              }
-      end
+  @typedoc """
+  Wraps layout (like Grid, Overlay etc.) with mapping of input objects
+  (which rendered output frames will be passed as inputs into layout).
+  Specifies resolution of layout output frame - if object name is passed
+  as resolution, it'll use resolution of object's output frame.
+  """
+  @type t :: %__MODULE__{
+          inputs_map: %{Object.name_t() => any()},
+          layout: LayoutSpec.definition_t(),
+          resolution: Resolution.t() | Object.name_t()
+        }
+end

--- a/lib/membrane/video_compositor/scene/layout_spec.ex
+++ b/lib/membrane/video_compositor/scene/layout_spec.ex
@@ -1,0 +1,5 @@
+defmodule Membrane.VideoCompositor.Scene.LayoutSpec do
+  @moduledoc false
+
+  @type definition_t :: struct() | module()
+end

--- a/lib/membrane/video_compositor/scene/layout_spec.ex
+++ b/lib/membrane/video_compositor/scene/layout_spec.ex
@@ -1,5 +1,12 @@
 defmodule Membrane.VideoCompositor.Scene.LayoutSpec do
-  @moduledoc false
+  @moduledoc """
+  Layouts can take multiple renderable objects as an input and
+  combine them into one frame. Fadings, Grids, Overlays, Transitions
+  etc. can be defined as Layouts.
+  """
 
+  @typedoc """
+  Layouts are represented my modules or module structs.
+  """
   @type definition_t :: struct() | module()
 end

--- a/lib/membrane/video_compositor/scene/object.ex
+++ b/lib/membrane/video_compositor/scene/object.ex
@@ -1,9 +1,19 @@
 defmodule Membrane.VideoCompositor.Scene.Object do
-  @moduledoc false
-  alias Membrane.VideoCompositor.Scene.Layout
-  alias Membrane.VideoCompositor.Scene.Texture
+  @moduledoc """
+  Renderable instance in Video Compositor.
+  Each object can be an input for transformation or layout
+  and at a low level will be rendered as simple texture before being
+  processed in transformation / layout.
+  """
+  alias Membrane.VideoCompositor.Scene.{Layout, Texture}
 
+  @typedoc """
+  Defines what can be used as an object name
+  """
   @type name_t :: atom() | tuple()
 
+  @typedoc """
+  Defines all renderable objects types in Video Compositor.
+  """
   @type t :: Texture.t() | Layout.t()
 end

--- a/lib/membrane/video_compositor/scene/object.ex
+++ b/lib/membrane/video_compositor/scene/object.ex
@@ -1,0 +1,9 @@
+defmodule Membrane.VideoCompositor.Scene.Object do
+  @moduledoc false
+  alias Membrane.VideoCompositor.Scene.Layout
+  alias Membrane.VideoCompositor.Scene.Texture
+
+  @type name_t :: atom() | tuple()
+
+  @type t :: Texture.t() | Layout.t()
+end

--- a/lib/membrane/video_compositor/scene/resolution.ex
+++ b/lib/membrane/video_compositor/scene/resolution.ex
@@ -1,0 +1,12 @@
+defmodule Membrane.VideoCompositor.Scene.Resolution do
+  @moduledoc false
+
+  @enforce_keys [:width, :height]
+  defstruct @enforce_keys
+
+  @type t ::
+          %__MODULE__{
+            width: non_neg_integer(),
+            height: non_neg_integer()
+          }
+end

--- a/lib/membrane/video_compositor/scene/resolution.ex
+++ b/lib/membrane/video_compositor/scene/resolution.ex
@@ -1,9 +1,14 @@
 defmodule Membrane.VideoCompositor.Scene.Resolution do
-  @moduledoc false
+  @moduledoc """
+  Simple resolution definition.
+  """
 
   @enforce_keys [:width, :height]
   defstruct @enforce_keys
 
+  @typedoc """
+  Defines frame / video resolution.
+  """
   @type t ::
           %__MODULE__{
             width: non_neg_integer(),

--- a/lib/membrane/video_compositor/scene/texture.ex
+++ b/lib/membrane/video_compositor/scene/texture.ex
@@ -1,5 +1,9 @@
 defmodule Membrane.VideoCompositor.Scene.Texture do
-  @moduledoc false
+  @moduledoc """
+  Texture takes frame received from Video Compositor objects,
+  apply all transformations and can be passed as an input
+  for other objects.
+  """
 
   alias Membrane.VideoCompositor.Scene.Object
   alias Membrane.VideoCompositor.Scene.Resolution
@@ -8,6 +12,11 @@ defmodule Membrane.VideoCompositor.Scene.Texture do
   @enforce_keys [:input, :transformations]
   defstruct @enforce_keys ++ [resolution: :transformed_input_resolution]
 
+  @typedoc """
+  Defines texture object, that takes frames from input Object (rendered frame),
+  apply all transformations sequentially and can be passed as an input for other
+  objects. Resolution of output frame is
+  """
   @type t :: %__MODULE__{
           input: Object.name_t(),
           transformations: [TransformationSpec.definition_t()],

--- a/lib/membrane/video_compositor/scene/texture.ex
+++ b/lib/membrane/video_compositor/scene/texture.ex
@@ -1,0 +1,16 @@
+defmodule Membrane.VideoCompositor.Scene.Texture do
+  @moduledoc false
+
+  alias Membrane.VideoCompositor.Scene.Object
+  alias Membrane.VideoCompositor.Scene.Resolution
+  alias Membrane.VideoCompositor.Scene.TransformationSpec
+
+  @enforce_keys [:input, :transformations]
+  defstruct @enforce_keys ++ [resolution: :transformed_input_resolution]
+
+  @type t :: %__MODULE__{
+          input: Object.name_t(),
+          transformations: [TransformationSpec.definition_t()],
+          resolution: Resolution.t() | :transformed_input_resolution
+        }
+end

--- a/lib/membrane/video_compositor/scene/transformation_spec.ex
+++ b/lib/membrane/video_compositor/scene/transformation_spec.ex
@@ -1,0 +1,5 @@
+defmodule Membrane.VideoCompositor.Scene.TransformationSpec do
+  @moduledoc false
+
+  @type definition_t :: struct() | module()
+end

--- a/lib/membrane/video_compositor/scene/transformation_spec.ex
+++ b/lib/membrane/video_compositor/scene/transformation_spec.ex
@@ -1,5 +1,12 @@
 defmodule Membrane.VideoCompositor.Scene.TransformationSpec do
-  @moduledoc false
+  @moduledoc """
+  Defines how transformation should look like.
+  """
 
+  @typedoc """
+  Transformations are single frame input - single frame output objects, that can be
+  defied with modules or module structs. Transformations can change frame resolution.
+  Cropping, CornersRounding, ColorFiler, RollToBall etc. can be implemented as transformations.
+  """
   @type definition_t :: struct() | module()
 end


### PR DESCRIPTION
Original Scene API seems not to follow the Membrane motto `Make simple things easy and hard things possible`, at least in my opinion. This is my take on simplifying it while trying to tackle the problem of low-level canvases implementations (which raised some questions in last week). 