### PR TITLE
Cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Since parts of this package are implemented in Rust, you need to have a Rust ins
 
 ## Usage
 
-TODO
+Before jumping into Livebook, check out this [installation guide](https://github.com/membraneframework/guide/tree/master/livebook_examples).
+
+[![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fmembraneframework%2Fguide%2Fblob%2Fmaster%2Flivebook_examples%2Fvideo_compositor%2Fvideo_compositor.livemd)
 
 ## Copyright and License
 

--- a/lib/membrane/video_compositor/examples/hard.ex
+++ b/lib/membrane/video_compositor/examples/hard.ex
@@ -9,7 +9,7 @@ defmodule Membrane.VideoCompositor.Examples.Hard do
   - The third video is turned into a ball and put in the middle bottom of the screen
   """
 
-  alias Membrane.VideoCompositor.VideoTransformations.TextureTransformations.CornersRounding
+  alias Membrane.VideoCompositor.TextureTransformations.CornersRounding
 
   alias Membrane.VideoCompositor.Examples.Mock.Layouts.{Grid, Merging}
   alias Membrane.VideoCompositor.Examples.Mock.Transformations.{Rotate, ToBall}

--- a/lib/membrane/video_compositor/texture_transformations.ex
+++ b/lib/membrane/video_compositor/texture_transformations.ex
@@ -1,4 +1,4 @@
-defmodule Membrane.VideoCompositor.VideoTransformations.TextureTransformations do
+defmodule Membrane.VideoCompositor.TextureTransformations do
   @moduledoc """
   Describes all texture transformations applied to video.
   Texture transformations can change resolution of frame.
@@ -10,7 +10,7 @@ defmodule Membrane.VideoCompositor.VideoTransformations.TextureTransformations d
   this type definition.
   """
 
-  alias Membrane.VideoCompositor.VideoTransformations.TextureTransformations.{
+  alias Membrane.VideoCompositor.TextureTransformations.{
     CornersRounding,
     Cropping
   }

--- a/lib/membrane/video_compositor/texture_transformations/corners_rounding.ex
+++ b/lib/membrane/video_compositor/texture_transformations/corners_rounding.ex
@@ -1,4 +1,4 @@
-defmodule Membrane.VideoCompositor.VideoTransformations.TextureTransformations.CornersRounding do
+defmodule Membrane.VideoCompositor.TextureTransformations.CornersRounding do
   @moduledoc """
   Describe corners rounding texture transformation parameter.
   Corner rounding transformation can be imagined as placing four circles with specified radius
@@ -10,10 +10,10 @@ defmodule Membrane.VideoCompositor.VideoTransformations.TextureTransformations.C
   ## Examples
     Example struct describing transformation which rounds corners with 100 pixel radius:
 
-      iex> alias Membrane.VideoCompositor.VideoTransformations.TextureTransformations.CornersRounding
-      Membrane.VideoCompositor.VideoTransformations.TextureTransformations.CornersRounding
+      iex> alias Membrane.VideoCompositor.TextureTransformations.CornersRounding
+      Membrane.VideoCompositor.TextureTransformations.CornersRounding
       iex> %CornersRounding{ border_radius: 100 }
-      %Membrane.VideoCompositor.VideoTransformations.TextureTransformations.CornersRounding{
+      %Membrane.VideoCompositor.TextureTransformations.CornersRounding{
         border_radius: 100
       }
   """

--- a/lib/membrane/video_compositor/texture_transformations/cropping.ex
+++ b/lib/membrane/video_compositor/texture_transformations/cropping.ex
@@ -1,4 +1,4 @@
-defmodule Membrane.VideoCompositor.VideoTransformations.TextureTransformations.Cropping do
+defmodule Membrane.VideoCompositor.TextureTransformations.Cropping do
   @moduledoc """
   Describe cropping texture transformation parameters.
   ## Values

--- a/lib/membrane/video_compositor/video_transformations.ex
+++ b/lib/membrane/video_compositor/video_transformations.ex
@@ -5,8 +5,7 @@ defmodule Membrane.VideoCompositor.VideoTransformations do
   applied in the order in which they appear in the list.
   """
 
-  alias Membrane.VideoCompositor.VideoTransformations
-  alias Membrane.VideoCompositor.VideoTransformations.TextureTransformations
+  alias Membrane.VideoCompositor.{TextureTransformations, VideoTransformations}
 
   @type t :: %__MODULE__{
           texture_transformations: list(TextureTransformations.t())

--- a/mix.exs
+++ b/mix.exs
@@ -94,13 +94,15 @@ defmodule Membrane.VideoCompositor.Mixfile do
       extras: ["README.md", "LICENSE"],
       formatters: ["html"],
       source_ref: "v#{@version}",
+      filter_modules:
+        ~r/Membrane\.VideoCompositor(\.VideoTransformations$|\.TextureTransformations.*|\.RustStructs\.BaseVideoPlacement|$)/,
       nest_modules_by_prefix: [
         Membrane.VideoCompositor,
-        Membrane.VideoCompositor.VideoTransformations
+        Membrane.VideoCompositor.TextureTransformations
       ],
       groups_for_modules: [
-        "Video transformations": [
-          ~r/^Membrane\.VideoCompositor\.VideoTransformations($|\.)/
+        "Texture transformations": [
+          ~r/^Membrane\.VideoCompositor\.TextureTransformations($|\.)/
         ]
       ]
     ]

--- a/native/membrane_videocompositor/src/elixir_bridge/elixir_structs.rs
+++ b/native/membrane_videocompositor/src/elixir_bridge/elixir_structs.rs
@@ -87,7 +87,7 @@ impl Into<Box<dyn TextureTransformation>> for ElixirTextureTransformations {
 
 /// Elixir struct wrapping parameters describing corner rounding texture transformation
 #[derive(Debug, rustler::NifStruct, Clone, Copy)]
-#[module = "Membrane.VideoCompositor.VideoTransformations.TextureTransformations.CornersRounding"]
+#[module = "Membrane.VideoCompositor.TextureTransformations.CornersRounding"]
 pub struct ElixirCornersRounding {
     pub border_radius: u32,
 }
@@ -104,7 +104,7 @@ impl Into<Box<dyn TextureTransformation>> for ElixirCornersRounding {
 
 /// Elixir struct wrapping parameters describing cropping texture transformation
 #[derive(Debug, rustler::NifStruct, Clone, Copy)]
-#[module = "Membrane.VideoCompositor.VideoTransformations.TextureTransformations.Cropping"]
+#[module = "Membrane.VideoCompositor.TextureTransformations.Cropping"]
 pub struct ElixirCropping {
     pub crop_top_left_corner: (f32, f32),
     pub crop_size: (f32, f32),

--- a/test/texture_transformations_test.exs
+++ b/test/texture_transformations_test.exs
@@ -12,7 +12,7 @@ defmodule Membrane.VideoCompositor.Test.TextureTransformations do
   alias Membrane.VideoCompositor.Test.Support.Utils
   alias Membrane.VideoCompositor.VideoTransformations
 
-  alias Membrane.VideoCompositor.VideoTransformations.TextureTransformations.{
+  alias Membrane.VideoCompositor.TextureTransformations.{
     CornersRounding,
     Cropping
   }


### PR DESCRIPTION
This PR
- Cleanup list of nested modules
- Filter out unwanted doc modules
- Add Livebook badge
- Move `VideoTransformations.TextureTransformations` to `TextureTransformations`