### PR TITLE
Tag nifs properly (as dirty IO-bound)

### DIFF
--- a/native/membrane_videocompositor/src/elixir_bridge.rs
+++ b/native/membrane_videocompositor/src/elixir_bridge.rs
@@ -100,10 +100,13 @@ fn init(
     #[allow(unused)] env: rustler::Env,
     output_stream_format: ElixirRawVideo,
 ) -> Result<(rustler::Atom, rustler::ResourceArc<State>), rustler::Error> {
-    Ok((
-        atoms::ok(),
-        rustler::ResourceArc::new(State::new(output_stream_format.try_into()?)?),
-    ))
+    let stream_format = output_stream_format.try_into()?;
+
+    let result = std::thread::spawn(move || State::new(stream_format))
+        .join()
+        .expect("Couldn't join the thread responsible for initializing the compositor")?;
+
+    Ok((atoms::ok(), rustler::ResourceArc::new(result)))
 }
 
 enum UploadFrameResult<'a> {

--- a/native/membrane_videocompositor/src/elixir_bridge.rs
+++ b/native/membrane_videocompositor/src/elixir_bridge.rs
@@ -95,7 +95,7 @@ impl InnerState {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn init(
     #[allow(unused)] env: rustler::Env,
     output_stream_format: ElixirRawVideo,
@@ -120,7 +120,7 @@ impl rustler::Encoder for UploadFrameResult<'_> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn process_frame<'a>(
     env: rustler::Env<'a>,
     state: ResourceArc<State>,
@@ -140,7 +140,7 @@ fn process_frame<'a>(
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn force_render(
     env: rustler::Env<'_>,
     state: ResourceArc<State>,
@@ -166,7 +166,7 @@ fn get_frame(state: &mut InnerState) -> (rustler::OwnedBinary, u64) {
     (output, pts)
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn add_video(
     #[allow(unused)] env: rustler::Env<'_>,
     state: rustler::ResourceArc<State>,
@@ -205,7 +205,7 @@ pub fn convert_z(z: f32) -> f32 {
     1.0 - z.max(1e-7)
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn update_stream_format(
     #[allow(unused)] env: rustler::Env<'_>,
     state: rustler::ResourceArc<State>,
@@ -227,7 +227,7 @@ fn update_stream_format(
     Ok(atoms::ok())
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn update_placement(
     #[allow(unused)] env: rustler::Env<'_>,
     state: rustler::ResourceArc<State>,
@@ -245,7 +245,7 @@ fn update_placement(
     Ok(atoms::ok())
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn update_transformations(
     #[allow(unused)] env: rustler::Env<'_>,
     state: rustler::ResourceArc<State>,
@@ -263,7 +263,7 @@ fn update_transformations(
     Ok(atoms::ok())
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn remove_video(
     #[allow(unused)] env: rustler::Env<'_>,
     state: ResourceArc<State>,
@@ -273,7 +273,7 @@ fn remove_video(
     Ok(atoms::ok())
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyIo")]
 fn send_end_of_stream(
     #[allow(unused)] env: rustler::Env<'_>,
     state: ResourceArc<State>,


### PR DESCRIPTION
We have been doing this wrong for a very long time. This was caused by rustler's poor documentation of this feature.