### PR TITLE
Ms 539 deserialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,25 +28,6 @@ jobs:
           command: |
               cargo test --workspace --manifest-path native/Cargo.toml
 
-  elixir_test_with_software_rendering:
-    docker:
-      - image: membraneframeworklabs/docker_membrane:opengl-experimental
-        environment:
-          XDG_RUNTIME_DIR: /tmp
-
-    steps:
-      - checkout
-      - setup_remote_docker
-      - elixir/get_mix_deps
-      # - elixir/use_build_cache:
-      #     env: test
-      - run:
-          command: mix deps.compile
-          name: Ensure native deps are compiled
-      - run:
-          command: mix test --warnings-as-errors
-          name: Run all tests
-
 workflows:
   build:
     jobs:
@@ -54,7 +35,7 @@ workflows:
           filters: &filters
             tags:
               only: /v.*/
-      - elixir_test_with_software_rendering:
+      - elixir/test:
           filters:
             <<: *filters
       - elixir/lint:
@@ -69,7 +50,7 @@ workflows:
       - elixir/hex_publish:
           requires:
             - elixir/build_test
-            - elixir_test_with_software_rendering
+            - elixir/test
             - elixir/lint
             - rust_lint
             - rust_tests

--- a/lib/membrane/video_compositor/object/layout.ex
+++ b/lib/membrane/video_compositor/object/layout.ex
@@ -22,11 +22,11 @@ defmodule Membrane.VideoCompositor.Object.Layout do
   ## Examples
   A simple layout could have an `inputs` map that looks like this:
 
-    %{
-      background: :video1,
-      main_presenter: :video2,
-      side_presenter: :video3,
-    }
+      %{
+        background: :video1,
+        main_presenter: :video2,
+        side_presenter: :video3,
+      }
 
   Keep in mind that this maps __internal names__ => __scene object names__
   """

--- a/lib/membrane/video_compositor/object/layout.ex
+++ b/lib/membrane/video_compositor/object/layout.ex
@@ -82,11 +82,10 @@ defmodule Membrane.VideoCompositor.Object.Layout do
     @type t :: %__MODULE__{
             :inputs => inputs(),
             :resolution => output_resolution(),
-            # unsure about calling this `implementation`.
-            :implementation => Layout.rust_representation()
+            :params => Layout.rust_representation()
           }
 
-    @enforce_keys [:inputs, :resolution, :implementation]
+    @enforce_keys [:inputs, :resolution, :params]
     defstruct @enforce_keys
   end
 
@@ -139,7 +138,7 @@ defmodule Membrane.VideoCompositor.Object.Layout do
     %RustlerFriendly{
       inputs: encoded_inputs,
       resolution: encoded_resolution,
-      implementation: rust_representation
+      params: rust_representation
     }
   end
 

--- a/lib/membrane/video_compositor/object/layout.ex
+++ b/lib/membrane/video_compositor/object/layout.ex
@@ -97,7 +97,7 @@ defmodule Membrane.VideoCompositor.Object.Layout do
 
   Keep in mind the layout needs to be registered before it's used in a scene graph.
   """
-  @opaque rust_representation :: {non_neg_integer(), non_neg_integer()}
+  @opaque rust_representation :: {String.t(), {non_neg_integer(), non_neg_integer()}}
 
   @typedoc """
   This type is an initialized layout that needs to be transported through elixir to the compositor.

--- a/lib/membrane/video_compositor/object/layout.ex
+++ b/lib/membrane/video_compositor/object/layout.ex
@@ -21,13 +21,12 @@ defmodule Membrane.VideoCompositor.Object.Layout do
 
   ## Examples
   A simple layout could have an `inputs` map that looks like this:
-  ```elixir
-  %{
-    background: :video1,
-    main_presenter: :video2,
-    side_presenter: :video3,
-  }
-  ```
+
+    %{
+      background: :video1,
+      main_presenter: :video2,
+      side_presenter: :video3,
+    }
 
   Keep in mind that this maps __internal names__ => __scene object names__
   """
@@ -37,8 +36,8 @@ defmodule Membrane.VideoCompositor.Object.Layout do
   Defines how the output resolution of a layout texture can be specified.
 
   Texture resolution can be specified as:
-  - plain `Membrane.VideoCompositor.Resolution.t()`
-  - resolution of another object
+    - plain `Membrane.VideoCompositor.Resolution.t()`
+    - resolution of another object
   """
   @type output_resolution :: Resolution.t() | Object.name()
 

--- a/lib/membrane/video_compositor/transformation.ex
+++ b/lib/membrane/video_compositor/transformation.ex
@@ -30,7 +30,7 @@ defmodule Membrane.VideoCompositor.Transformation do
 
   Keep in mind the transformation needs to be registered before it's used in a scene graph.
   """
-  @opaque rust_representation :: {non_neg_integer(), non_neg_integer()}
+  @opaque rust_representation :: {String.t(), {non_neg_integer(), non_neg_integer()}}
 
   @typedoc """
   This type is an initialized transformation that needs to be transported through elixir to the compositor.

--- a/lib/membrane/video_compositor/wgpu/native.ex
+++ b/lib/membrane/video_compositor/wgpu/native.ex
@@ -37,5 +37,9 @@ defmodule Membrane.VideoCompositor.Wgpu.Native do
           Membrane.VideoCompositor.Transformation.initialized_transformation()
   def mock_transformation(_wgpu_ctx), do: error()
 
+  @spec encode_mock_transformation(String.t()) ::
+          Membrane.VideoCompositor.Transformation.rust_representation()
+  def encode_mock_transformation(_arg), do: error()
+
   defp error(), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/membrane_video_compositor/src/compositor.rs
+++ b/native/membrane_video_compositor/src/compositor.rs
@@ -7,7 +7,7 @@ use membrane_video_compositor_common::plugins::layout::UntypedLayout;
 use membrane_video_compositor_common::plugins::transformation::{
     Transformation, UntypedTransformation,
 };
-use membrane_video_compositor_common::plugins::{CustomProcessor, PluginRegistryKey};
+use membrane_video_compositor_common::plugins::{PluginArgumentEncoder, PluginRegistryKey};
 use membrane_video_compositor_common::WgpuContext;
 
 use self::errors::CompositorError;
@@ -85,7 +85,7 @@ impl MockTransformation {
     const NAME: &str = "mock_transformation";
 }
 
-impl CustomProcessor for MockTransformation {
+impl PluginArgumentEncoder for MockTransformation {
     type Arg = String;
 
     fn registry_key() -> PluginRegistryKey<'static>
@@ -121,7 +121,7 @@ pub fn mock_transformation(ctx: StructElixirPacket<WgpuContext>) -> Transformati
 
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn encode_mock_transformation(
-    arg: <MockTransformation as CustomProcessor>::Arg,
+    arg: <MockTransformation as PluginArgumentEncoder>::Arg,
 ) -> CustomStructElixirPacket {
     unsafe { MockTransformation::encode_arg(arg) }
 }

--- a/native/membrane_video_compositor/src/compositor.rs
+++ b/native/membrane_video_compositor/src/compositor.rs
@@ -64,35 +64,32 @@ impl InnerState {
         &mut self,
         transformation: Arc<dyn UntypedTransformation>,
     ) -> Result<(), CompositorError> {
-        if self
-            .plugin_registry
-            .contains_key(&transformation.registry_key())
-        {
-            return Err(CompositorError::RegistryKeyTaken(
-                transformation.registry_key().0.to_string(),
-            ));
-        }
-
-        self.plugin_registry.insert(
+        self.register(
             transformation.registry_key(),
             PluginRegistryEntry::Transformation(transformation),
-        );
-
-        Ok(())
+        )
     }
 
     pub fn register_layout(
         &mut self,
         layout: Arc<dyn UntypedLayout>,
     ) -> Result<(), CompositorError> {
-        if self.plugin_registry.contains_key(&layout.registry_key()) {
+        self.register(layout.registry_key(), PluginRegistryEntry::Layout(layout))
+    }
+
+    fn register(
+        &mut self,
+        registry_key: PluginRegistryKey<'static>,
+        plugin: PluginRegistryEntry,
+    ) -> Result<(), CompositorError> {
+        if self.plugin_registry.contains_key(&registry_key) {
             return Err(CompositorError::RegistryKeyTaken(
-                layout.registry_key().0.to_string(),
+                registry_key.0.to_string(),
             ));
         }
 
-        self.plugin_registry
-            .insert(layout.registry_key(), PluginRegistryEntry::Layout(layout));
+        self.plugin_registry.insert(registry_key, plugin);
+
         Ok(())
     }
 }

--- a/native/membrane_video_compositor/src/compositor.rs
+++ b/native/membrane_video_compositor/src/compositor.rs
@@ -94,10 +94,6 @@ impl PluginArgumentEncoder for MockTransformation {
     {
         PluginRegistryKey(Self::NAME)
     }
-
-    fn registry_key_dyn(&self) -> PluginRegistryKey<'static> {
-        PluginRegistryKey(Self::NAME)
-    }
 }
 
 impl Transformation for MockTransformation {

--- a/native/membrane_video_compositor/src/compositor/errors.rs
+++ b/native/membrane_video_compositor/src/compositor/errors.rs
@@ -1,10 +1,7 @@
 #[derive(Debug, thiserror::Error)]
 pub enum CompositorError {
-    #[error("Tried to register a transformation called {0}. This name is already taken.")]
-    TransformationNameTaken(String),
-
-    #[error("Tried to register a layout called {0}. This name is already taken.")]
-    LayoutNameTaken(String),
+    #[error("Tried to register a transformation or layout with registry key \"{0}\". This registry key is already taken.")]
+    RegistryKeyTaken(String),
 }
 
 mod atoms {
@@ -17,11 +14,8 @@ mod atoms {
 impl rustler::Encoder for CompositorError {
     fn encode<'a>(&self, env: rustler::Env<'a>) -> rustler::Term<'a> {
         match self {
-            CompositorError::TransformationNameTaken(name) => {
+            CompositorError::RegistryKeyTaken(name) => {
                 (atoms::transformation_name_taken(), name).encode(env)
-            }
-            CompositorError::LayoutNameTaken(name) => {
-                (atoms::layout_name_taken(), name).encode(env)
             }
         }
     }

--- a/native/membrane_video_compositor/src/compositor/errors.rs
+++ b/native/membrane_video_compositor/src/compositor/errors.rs
@@ -1,21 +1,20 @@
 #[derive(Debug, thiserror::Error)]
 pub enum CompositorError {
-    #[error("Tried to register a transformation or layout with registry key \"{0}\". This registry key is already taken.")]
-    RegistryKeyTaken(String),
+    #[error("Plugin registry error")]
+    PluginRegistryError(#[from] super::registry::PluginRegistryError),
 }
 
 mod atoms {
     rustler::atoms! {
-        transformation_name_taken,
-        layout_name_taken,
+        plugin_registry_error,
     }
 }
 
 impl rustler::Encoder for CompositorError {
     fn encode<'a>(&self, env: rustler::Env<'a>) -> rustler::Term<'a> {
         match self {
-            CompositorError::RegistryKeyTaken(name) => {
-                (atoms::transformation_name_taken(), name).encode(env)
+            CompositorError::PluginRegistryError(err) => {
+                (atoms::plugin_registry_error(), err.to_string()).encode(env)
             }
         }
     }

--- a/native/membrane_video_compositor/src/compositor/registry.rs
+++ b/native/membrane_video_compositor/src/compositor/registry.rs
@@ -1,0 +1,57 @@
+use std::{collections::HashMap, sync::Arc};
+
+use membrane_video_compositor_common::plugins::{
+    layout::UntypedLayout, transformation::UntypedTransformation, PluginRegistryKey,
+};
+
+pub enum PluginRegistryEntry {
+    Layout(Arc<dyn UntypedLayout>),
+    Transformation(Arc<dyn UntypedTransformation>),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PluginRegistryError {
+    #[error("Tried to register a transformation or layout with registry key \"{0}\". This registry key is already taken.")]
+    KeyAlreadyTaken(String),
+
+    #[error("Tried to lookup an entry with an unregistered key: {0}")]
+    EntryNotFound(String),
+}
+
+type Result<T> = std::result::Result<T, PluginRegistryError>;
+
+#[derive(Default)]
+pub struct PluginRegistry {
+    registry: HashMap<PluginRegistryKey<'static>, PluginRegistryEntry>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        Self {
+            registry: HashMap::new(),
+        }
+    }
+
+    pub fn register(
+        &mut self,
+        key: PluginRegistryKey<'static>,
+        entry: PluginRegistryEntry,
+    ) -> Result<()> {
+        if self.registry.contains_key(&key) {
+            return Err(PluginRegistryError::KeyAlreadyTaken(key.0.into()));
+        }
+
+        self.registry.insert(key, entry);
+
+        Ok(())
+    }
+
+    #[allow(dead_code)] // NOTE: this is for now, until we actually start using this
+    pub fn get<'a>(&'a self, key: &PluginRegistryKey<'a>) -> Result<&PluginRegistryEntry> {
+        if let Some(v) = self.registry.get(key) {
+            Ok(v)
+        } else {
+            Err(PluginRegistryError::EntryNotFound(key.0.to_string()))
+        }
+    }
+}

--- a/native/membrane_video_compositor/src/elixir_bridge.rs
+++ b/native/membrane_video_compositor/src/elixir_bridge.rs
@@ -66,6 +66,7 @@ rustler::init!(
         register_transformation,
         register_layout,
         compositor::mock_transformation,
+        compositor::encode_mock_transformation,
     ],
     load = |env, _| {
         rustler::resource!(crate::compositor::State, env);

--- a/native/membrane_video_compositor/src/elixir_bridge/elixir_structs.rs
+++ b/native/membrane_video_compositor/src/elixir_bridge/elixir_structs.rs
@@ -255,7 +255,7 @@ impl<'a> Scene<'a> {
                     for transformation in transformations {
                         current = Arc::new(Node::Transformation {
                             previous: current,
-                            transformation,
+                            params: transformation,
                             resolution: resolution.clone(),
                         });
                     }
@@ -386,17 +386,17 @@ mod tests {
 
         let final_node = scene.final_node;
 
-        let Node::Transformation { ref previous, transformation, .. } = &*final_node else {
+        let Node::Transformation { ref previous, params: transformation, .. } = &*final_node else {
             panic!("unexpected scene structure");
         };
         assert_eq!(transformation.recipient_registry_key, "c");
 
-        let Node::Transformation { ref previous, transformation, .. } = &**previous else {
+        let Node::Transformation { ref previous, params: transformation, .. } = &**previous else {
             panic!("unexpected scene structure");
         };
         assert_eq!(transformation.recipient_registry_key, "b");
 
-        let Node::Transformation { transformation, .. } = &**previous else {
+        let Node::Transformation { params: transformation, .. } = &**previous else {
             panic!("unexpected scene structure");
         };
         assert_eq!(transformation.recipient_registry_key, "a");

--- a/native/membrane_video_compositor/src/elixir_bridge/scene_validation.rs
+++ b/native/membrane_video_compositor/src/elixir_bridge/scene_validation.rs
@@ -193,6 +193,10 @@ impl From<SceneParsingError> for rustler::Error {
 
 #[cfg(test)]
 mod test {
+    use membrane_video_compositor_common::{
+        elixir_transfer::CustomStructElixirPacket, plugins::PluginRegistryKey,
+    };
+
     use super::*;
 
     #[test]
@@ -342,7 +346,9 @@ mod test {
                     Object::Layout(Layout {
                         inputs,
                         resolution: LayoutOutputResolution::Name(a),
-                        implementation: (42, 42),
+                        params: unsafe {
+                            CustomStructElixirPacket::encode(0, PluginRegistryKey("a"))
+                        },
                     }),
                 ),
             ],
@@ -386,7 +392,9 @@ mod test {
                     Object::Layout(Layout {
                         inputs,
                         resolution: LayoutOutputResolution::Name(a),
-                        implementation: (42, 42),
+                        params: unsafe {
+                            CustomStructElixirPacket::encode(0, PluginRegistryKey("a"))
+                        },
                     }),
                 ),
                 (

--- a/native/membrane_video_compositor/src/scene.rs
+++ b/native/membrane_video_compositor/src/scene.rs
@@ -1,8 +1,9 @@
 use std::{collections::HashMap, sync::Arc};
 
+use membrane_video_compositor_common::elixir_transfer::CustomStructElixirPacket;
+
 use crate::elixir_bridge::elixir_structs::{
-    ImplementationPlaceholder, LayoutInternalName, LayoutOutputResolution, PadRef, Resolution,
-    TextureOutputResolution,
+    LayoutInternalName, LayoutOutputResolution, PadRef, Resolution, TextureOutputResolution,
 };
 
 /// A node represents a single object in the video-processing graph.
@@ -13,7 +14,8 @@ pub enum Node {
     /// This could, for example, arrange a couple of videos in a grid.
     Layout {
         resolution: LayoutOutputResolution,
-        implementation: ImplementationPlaceholder,
+        // TODO: When we're ready, this should be swapped for `DecodedCustomStructElixirPacket`
+        params: CustomStructElixirPacket,
         inputs: HashMap<LayoutInternalName, Arc<Node>>,
     },
 
@@ -22,7 +24,8 @@ pub enum Node {
     Transformation {
         resolution: TextureOutputResolution,
         previous: Arc<Node>,
-        transformation: ImplementationPlaceholder,
+        // TODO: When we're ready, this should be swapped for `DecodedCustomStructElixirPacket`
+        transformation: CustomStructElixirPacket,
     },
 
     /// This represents the node, through which video frames 'enter' the scene graph.

--- a/native/membrane_video_compositor/src/scene.rs
+++ b/native/membrane_video_compositor/src/scene.rs
@@ -25,7 +25,7 @@ pub enum Node {
         resolution: TextureOutputResolution,
         previous: Arc<Node>,
         // TODO: When we're ready, this should be swapped for `DecodedCustomStructElixirPacket`
-        transformation: CustomStructElixirPacket,
+        params: CustomStructElixirPacket,
     },
 
     /// This represents the node, through which video frames 'enter' the scene graph.

--- a/native/membrane_video_compositor_common/src/elixir_transfer.rs
+++ b/native/membrane_video_compositor_common/src/elixir_transfer.rs
@@ -15,12 +15,15 @@ impl CustomStructElixirPacket {
     /// # Safety
     /// The struct created with this function has to be consumed with [CustomStructElixirPacket::decode].
     /// Not consuming it will result in memory leaks or other unfortunate side-effects
-    pub unsafe fn encode<T: Send + 'static>(payload: T, recipient: PluginRegistryKey<'_>) -> Self {
+    pub unsafe fn encode<T: Send + 'static>(
+        payload: T,
+        recipient_key: PluginRegistryKey<'_>,
+    ) -> Self {
         let payload: Arc<dyn Any> = Arc::new(payload);
         let pointer = unsafe { std::mem::transmute(payload) };
 
         CustomStructElixirPacket {
-            recipient_registry_key: recipient.0.to_owned(),
+            recipient_registry_key: recipient_key.0.to_owned(),
             pointer,
         }
     }

--- a/native/membrane_video_compositor_common/src/elixir_transfer.rs
+++ b/native/membrane_video_compositor_common/src/elixir_transfer.rs
@@ -7,7 +7,7 @@ use crate::plugins::{
 /// This struct is meant for encoding and transferring structs defined and used only in the plugins
 /// (i.e. unknown during the compilation of the compositor)
 pub struct CustomStructElixirPacket {
-    recipient_registry_key: String,
+    pub recipient_registry_key: String,
     pointer: (usize, usize),
 }
 
@@ -41,6 +41,18 @@ impl CustomStructElixirPacket {
     }
 }
 
+impl std::fmt::Debug for CustomStructElixirPacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CustomStructElixirPacket")
+            .field("recipient_registry_key", &self.recipient_registry_key)
+            .field(
+                "pointer",
+                &(self.pointer.0 as *const (), self.pointer.1 as *const ()),
+            )
+            .finish()
+    }
+}
+
 impl<'a> rustler::Decoder<'a> for CustomStructElixirPacket {
     fn decode(term: rustler::Term<'a>) -> rustler::NifResult<Self> {
         let (recipient, pointer) = rustler::Decoder::decode(term)?;
@@ -69,6 +81,7 @@ impl DecodedCustomStructElixirPacket {
 }
 
 /// This struct is meant for encoding and transferring structs used both in the compositor and in the plugins
+// TODO: shouldn't this be `Sync`?
 pub struct StructElixirPacket<T: Send + 'static> {
     pointer: usize,
     _phantom: PhantomData<T>,

--- a/native/membrane_video_compositor_common/src/plugins.rs
+++ b/native/membrane_video_compositor_common/src/plugins.rs
@@ -9,13 +9,9 @@ pub struct PluginRegistryKey<'a>(pub &'a str);
 pub trait PluginArgumentEncoder: Send + Sync + 'static {
     type Arg: Send + 'static;
 
-    /// Should return the same thing as `registry_key_dyn`
     fn registry_key() -> PluginRegistryKey<'static>
     where
         Self: Sized;
-
-    /// Should return the same thing as `registry_key`
-    fn registry_key_dyn(&self) -> PluginRegistryKey<'static>;
 
     /// # Safety
     /// Carries the same contract as [CustomStructElixirPacket::encode]

--- a/native/membrane_video_compositor_common/src/plugins.rs
+++ b/native/membrane_video_compositor_common/src/plugins.rs
@@ -6,8 +6,7 @@ pub mod transformation;
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct PluginRegistryKey<'a>(pub &'a str);
 
-// Question for the reviewers: What should this trait be named? I don't like this name.
-pub trait CustomProcessor: Send + Sync + 'static {
+pub trait PluginArgumentEncoder: Send + Sync + 'static {
     type Arg: Send + 'static;
 
     /// Should return the same thing as `registry_key_dyn`

--- a/native/membrane_video_compositor_common/src/plugins.rs
+++ b/native/membrane_video_compositor_common/src/plugins.rs
@@ -1,2 +1,29 @@
+use crate::elixir_transfer::CustomStructElixirPacket;
+
 pub mod layout;
 pub mod transformation;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct PluginRegistryKey<'a>(pub &'a str);
+
+// Question for the reviewers: What should this trait be named? I don't like this name.
+pub trait CustomProcessor: Send + Sync + 'static {
+    type Arg: Send + 'static;
+
+    /// Should return the same thing as `name_dyn`
+    fn registry_key() -> PluginRegistryKey<'static>
+    where
+        Self: Sized;
+
+    /// Should return the same thing as `name`
+    fn registry_key_dyn(&self) -> PluginRegistryKey<'static>;
+
+    /// # Safety
+    /// Carries the same contract as [CustomStructElixirPacket::encode]
+    unsafe fn encode_arg(arg: Self::Arg) -> CustomStructElixirPacket
+    where
+        Self: Sized,
+    {
+        unsafe { CustomStructElixirPacket::encode(arg, Self::registry_key()) }
+    }
+}

--- a/native/membrane_video_compositor_common/src/plugins.rs
+++ b/native/membrane_video_compositor_common/src/plugins.rs
@@ -10,12 +10,12 @@ pub struct PluginRegistryKey<'a>(pub &'a str);
 pub trait CustomProcessor: Send + Sync + 'static {
     type Arg: Send + 'static;
 
-    /// Should return the same thing as `name_dyn`
+    /// Should return the same thing as `registry_key_dyn`
     fn registry_key() -> PluginRegistryKey<'static>
     where
         Self: Sized;
 
-    /// Should return the same thing as `name`
+    /// Should return the same thing as `registry_key`
     fn registry_key_dyn(&self) -> PluginRegistryKey<'static>;
 
     /// # Safety

--- a/native/membrane_video_compositor_common/src/plugins/layout.rs
+++ b/native/membrane_video_compositor_common/src/plugins/layout.rs
@@ -20,10 +20,6 @@ pub trait UntypedLayout: Send + Sync + 'static {
 
 impl<T: Layout> UntypedLayout for T {
     fn registry_key(&self) -> PluginRegistryKey<'static> {
-        assert_eq!(
-            <Self as PluginArgumentEncoder>::registry_key(),
-            self.registry_key_dyn()
-        );
         <Self as PluginArgumentEncoder>::registry_key()
     }
 

--- a/native/membrane_video_compositor_common/src/plugins/layout.rs
+++ b/native/membrane_video_compositor_common/src/plugins/layout.rs
@@ -2,11 +2,11 @@ use std::{any::Any, sync::Arc};
 
 use crate::WgpuContext;
 
-use super::{CustomProcessor, PluginRegistryKey};
+use super::{PluginArgumentEncoder, PluginRegistryKey};
 
 // NOTE: Send + Sync is necessary to store these in the compositor's state later.
 //       'static is necessary for sending across elixir
-pub trait Layout: CustomProcessor {
+pub trait Layout: PluginArgumentEncoder {
     fn do_stuff(&self, arg: &Self::Arg);
     fn new(ctx: Arc<WgpuContext>) -> Self
     where
@@ -21,10 +21,10 @@ pub trait UntypedLayout: Send + Sync + 'static {
 impl<T: Layout> UntypedLayout for T {
     fn registry_key(&self) -> PluginRegistryKey<'static> {
         assert_eq!(
-            <Self as CustomProcessor>::registry_key(),
+            <Self as PluginArgumentEncoder>::registry_key(),
             self.registry_key_dyn()
         );
-        <Self as CustomProcessor>::registry_key()
+        <Self as PluginArgumentEncoder>::registry_key()
     }
 
     fn do_stuff(&self, arg: &dyn Any) {

--- a/native/membrane_video_compositor_common/src/plugins/transformation.rs
+++ b/native/membrane_video_compositor_common/src/plugins/transformation.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, sync::Arc};
 
-use crate::{plugins::CustomProcessor, WgpuContext};
+use crate::{plugins::PluginArgumentEncoder, WgpuContext};
 
 use super::PluginRegistryKey;
 
@@ -18,11 +18,11 @@ use super::PluginRegistryKey;
 /// # use std::sync::Arc;
 /// # use membrane_video_compositor_common::WgpuContext;
 /// use membrane_video_compositor_common::elixir_transfer::{StructElixirPacket, TransformationElixirPacket};
-/// use membrane_video_compositor_common::plugins::{CustomProcessor, PluginRegistryKey, transformation::Transformation};
+/// use membrane_video_compositor_common::plugins::{PluginArgumentEncoder, PluginRegistryKey, transformation::Transformation};
 /// # struct CustomTransformation{}
 /// # struct CustomTransformationArg{}
 /// #
-/// # impl CustomProcessor for CustomTransformation {
+/// # impl PluginArgumentEncoder for CustomTransformation {
 /// #     type Arg = CustomTransformationArg;
 /// #     fn registry_key() -> PluginRegistryKey<'static>
 /// #     where
@@ -51,7 +51,7 @@ use super::PluginRegistryKey;
 ///     unsafe { TransformationElixirPacket::encode(CustomTransformation::new(ctx)) }
 /// }
 /// ```
-pub trait Transformation: CustomProcessor {
+pub trait Transformation: PluginArgumentEncoder {
     fn do_stuff(&self, arg: &Self::Arg);
 
     fn new(ctx: Arc<WgpuContext>) -> Self
@@ -67,10 +67,10 @@ pub trait UntypedTransformation: Send + Sync + 'static {
 impl<T: Transformation> UntypedTransformation for T {
     fn registry_key(&self) -> PluginRegistryKey<'static> {
         assert_eq!(
-            <Self as CustomProcessor>::registry_key(),
+            <Self as PluginArgumentEncoder>::registry_key(),
             self.registry_key_dyn()
         );
-        <Self as CustomProcessor>::registry_key()
+        <Self as PluginArgumentEncoder>::registry_key()
     }
 
     fn do_stuff(&self, arg: &dyn Any) {

--- a/native/membrane_video_compositor_common/src/plugins/transformation.rs
+++ b/native/membrane_video_compositor_common/src/plugins/transformation.rs
@@ -30,10 +30,6 @@ use super::PluginRegistryKey;
 /// #     {
 /// #         PluginRegistryKey("custom transformation")
 /// #     }
-/// #
-/// #     fn registry_key_dyn(&self) -> PluginRegistryKey<'static> {
-/// #         PluginRegistryKey("custom transformation")
-/// #     }
 /// # }
 /// #
 /// # impl Transformation for CustomTransformation {
@@ -66,10 +62,6 @@ pub trait UntypedTransformation: Send + Sync + 'static {
 
 impl<T: Transformation> UntypedTransformation for T {
     fn registry_key(&self) -> PluginRegistryKey<'static> {
-        assert_eq!(
-            <Self as PluginArgumentEncoder>::registry_key(),
-            self.registry_key_dyn()
-        );
         <Self as PluginArgumentEncoder>::registry_key()
     }
 

--- a/native/membrane_video_compositor_common/src/plugins/transformation.rs
+++ b/native/membrane_video_compositor_common/src/plugins/transformation.rs
@@ -1,6 +1,8 @@
 use std::{any::Any, sync::Arc};
 
-use crate::WgpuContext;
+use crate::{plugins::CustomProcessor, WgpuContext};
+
+use super::PluginRegistryKey;
 
 // Question to the reviewers: should the example below be in the finished documentation? Should it be
 //                            kept until the end of the plugins PR?
@@ -16,16 +18,25 @@ use crate::WgpuContext;
 /// # use std::sync::Arc;
 /// # use membrane_video_compositor_common::WgpuContext;
 /// use membrane_video_compositor_common::elixir_transfer::{StructElixirPacket, TransformationElixirPacket};
-/// use membrane_video_compositor_common::plugins::transformation::Transformation;
+/// use membrane_video_compositor_common::plugins::{CustomProcessor, PluginRegistryKey, transformation::Transformation};
 /// # struct CustomTransformation{}
 /// # struct CustomTransformationArg{}
-/// # impl Transformation for CustomTransformation {
+/// #
+/// # impl CustomProcessor for CustomTransformation {
 /// #     type Arg = CustomTransformationArg;
-/// #     
-/// #     fn name(&self) -> &'static str {
-/// #         "custom transformation"
+/// #     fn registry_key() -> PluginRegistryKey<'static>
+/// #     where
+/// #         Self: Sized
+/// #     {
+/// #         PluginRegistryKey("custom transformation")
 /// #     }
 /// #
+/// #     fn registry_key_dyn(&self) -> PluginRegistryKey<'static> {
+/// #         PluginRegistryKey("custom transformation")
+/// #     }
+/// # }
+/// #
+/// # impl Transformation for CustomTransformation {
 /// #     fn do_stuff(&self, arg: &Self::Arg) {}
 /// #     fn new(ctx: Arc<WgpuContext>) -> Self
 /// #     where
@@ -40,10 +51,7 @@ use crate::WgpuContext;
 ///     unsafe { TransformationElixirPacket::encode(CustomTransformation::new(ctx)) }
 /// }
 /// ```
-pub trait Transformation: Send + Sync + 'static {
-    type Arg: Send + 'static;
-
-    fn name(&self) -> &'static str;
+pub trait Transformation: CustomProcessor {
     fn do_stuff(&self, arg: &Self::Arg);
 
     fn new(ctx: Arc<WgpuContext>) -> Self
@@ -52,13 +60,17 @@ pub trait Transformation: Send + Sync + 'static {
 }
 
 pub trait UntypedTransformation: Send + Sync + 'static {
-    fn name(&self) -> &'static str;
+    fn registry_key(&self) -> PluginRegistryKey<'static>;
     fn do_stuff(&self, arg: &dyn Any);
 }
 
 impl<T: Transformation> UntypedTransformation for T {
-    fn name(&self) -> &'static str {
-        self.name()
+    fn registry_key(&self) -> PluginRegistryKey<'static> {
+        assert_eq!(
+            <Self as CustomProcessor>::registry_key(),
+            self.registry_key_dyn()
+        );
+        <Self as CustomProcessor>::registry_key()
     }
 
     fn do_stuff(&self, arg: &dyn Any) {

--- a/test/registering_transformation_test.exs
+++ b/test/registering_transformation_test.exs
@@ -12,8 +12,8 @@ defmodule Membrane.VideoCompositor.RegisteringTransformationTest do
     end
 
     @impl true
-    def encode(_transformation) do
-      {0xDEADBEEF, 0xDEADBEEF}
+    def encode(transformation) do
+      Native.encode_mock_transformation(transformation)
     end
   end
 

--- a/test/support/mock/layouts/grid.ex
+++ b/test/support/mock/layouts/grid.ex
@@ -28,6 +28,6 @@ defmodule Membrane.VideoCompositor.Mock.Layouts.Grid do
 
   @impl true
   def encode(_grid) do
-    {0xDEADBEEF, 0xDEADBEEF}
+    {"grid", {0xDEADBEEF, 0xDEADBEEF}}
   end
 end

--- a/test/support/mock/layouts/merging.ex
+++ b/test/support/mock/layouts/merging.ex
@@ -24,6 +24,6 @@ defmodule Membrane.VideoCompositor.Mock.Layouts.Merging do
 
   @impl true
   def encode(_merging) do
-    {0xDEADBEEF, 0xDEADBEEF}
+    {"merging", {0xDEADBEEF, 0xDEADBEEF}}
   end
 end

--- a/test/support/mock/layouts/overlay.ex
+++ b/test/support/mock/layouts/overlay.ex
@@ -29,7 +29,7 @@ defmodule Membrane.VideoCompositor.Mock.Layouts.Overlay do
         }
   @impl true
   def encode(_overlay) do
-    {0xDEADBEEF, 0xDEADBEEF}
+    {"overlay", {0xDEADBEEF, 0xDEADBEEF}}
   end
 
   @impl true

--- a/test/support/mock/transformations/corners_rounding.ex
+++ b/test/support/mock/transformations/corners_rounding.ex
@@ -22,7 +22,7 @@ defmodule Membrane.VideoCompositor.Mock.Transformations.CornersRounding do
 
   @impl true
   def encode(_corners_rounding) do
-    {0xDEADBEEF, 0xDEADBEEF}
+    {"corners_rounding", {0xDEADBEEF, 0xDEADBEEF}}
   end
 
   @impl true

--- a/test/support/mock/transformations/rotate.ex
+++ b/test/support/mock/transformations/rotate.ex
@@ -12,7 +12,7 @@ defmodule Membrane.VideoCompositor.Mock.Transformations.Rotate do
 
   @impl true
   def encode(_rotate) do
-    {0xDEADBEEF, 0xDEADBEEF}
+    {"rotate", {0xDEADBEEF, 0xDEADBEEF}}
   end
 
   @impl true

--- a/test/support/mock/transformations/to_ball.ex
+++ b/test/support/mock/transformations/to_ball.ex
@@ -3,6 +3,7 @@ defmodule Membrane.VideoCompositor.Mock.Transformations.ToBall do
 
   @behaviour Membrane.VideoCompositor.Transformation
 
+  # TODO: do sth about this, also: wire transformations so that they can be received
   @impl true
   def encode(_rotate) do
     {0xDEADBEEF, 0xDEADBEEF}

--- a/test/support/mock/transformations/to_ball.ex
+++ b/test/support/mock/transformations/to_ball.ex
@@ -3,10 +3,9 @@ defmodule Membrane.VideoCompositor.Mock.Transformations.ToBall do
 
   @behaviour Membrane.VideoCompositor.Transformation
 
-  # TODO: do sth about this, also: wire transformations so that they can be received
   @impl true
   def encode(_rotate) do
-    {0xDEADBEEF, 0xDEADBEEF}
+    {"to_ball", {0xDEADBEEF, 0xDEADBEEF}}
   end
 
   @impl true


### PR DESCRIPTION
- change the transformations and layouts to use `PluginRegistryKey`s instead of `name`s, which were raw strings
- add a `PluginRegistry` struct
- keep both transformations and layouts in a single registry, since they're both identified by a registry key
- extract the logic common to layouts and transformations into a new trait, `CustomTransformer`
- attach a string to each `CustomStructElixirPacket`, which allows to check which transformer it is related to 